### PR TITLE
Upgrade versions, Boolean attribute improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.21'
-    id "org.jetbrains.kotlin.jvm" version "1.3.72"
+    id 'org.jetbrains.intellij' version '1.5.2'
+    id "org.jetbrains.kotlin.jvm" version "1.6.10"
 }
 
 group 'dev.fritz2'
@@ -14,22 +14,20 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
-    compile fileTree(dir: 'libs', include: '*.jar')
-
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10"
+    // compile fileTree(dir: 'libs', include: '*.jar')
+    // testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2018.1'
+    version = '2022.1'
     plugins = ['Kotlin']
     patchPluginXml {
         untilBuild = "" // Be forward compatible
         // sinceBuild is inferred from the version above
-    }}
+    }
+}
 
 publishPlugin {
 //    token ORG_GRADLE_PROJECT_intellijPublishToken

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/dev/fritz2/htmlplugin/conversion/HtmlDataToFritz2.kt
+++ b/src/main/kotlin/dev/fritz2/htmlplugin/conversion/HtmlDataToFritz2.kt
@@ -126,7 +126,9 @@ fun HtmlAttribute.toFritz2Attribute(owner: HtmlTag? = null): String {
     val htmlAttrName = attrName
 
     val attrName = fritz2Attributes.find { it.equals(htmlAttrName, ignoreCase = true) }
-    val attrValue = if (attributesWithoutQuotes.contains(attrName)) """$value""" else """"$value""""
+    val attrValue = attrName?.let {
+        if (it.lowercase() == "true" || attributesWithoutQuotes.contains(it)) "$value" else """"$value""""
+    }
 
     return if (attrName != null) {
         val fritz2AttrName = when (attrName) {
@@ -142,12 +144,11 @@ fun HtmlAttribute.toFritz2Attribute(owner: HtmlTag? = null): String {
     } else {
         toFritz2DataAttribute(htmlAttrName, attrValue)
     }
-
 }
 
 fun HtmlAttribute.toFritz2Parameter(owner: HtmlTag? = null): String {
     // remap for fritz2
-    val attrNameLowerCase = attrName.toLowerCase()
+    val attrNameLowerCase = attrName.lowercase()
     val attrValue = "$value"
     val attrName = when (attrNameLowerCase) {
         "class" -> "baseClass"
@@ -158,15 +159,14 @@ fun HtmlAttribute.toFritz2Parameter(owner: HtmlTag? = null): String {
         value != null -> """$attrName = "$attrValue" """.trim()
         else -> """$attrName = true""".trim()
     }
-
 }
 
 
-fun HtmlAttribute.toFritz2DataAttribute(attrName: String, attrValue: String): String =
+fun HtmlAttribute.toFritz2DataAttribute(attrName: String, attrValue: String?): String =
     when {
-        !value.isNullOrEmpty() -> """attr("$attrName", "$value")""".trim()
-        else -> """attr("$attrName", true, trueValue = "")""".trim()
-    }
+        !attrValue.isNullOrEmpty() -> """attr("$attrName", "$attrValue")"""
+        else -> """attr("$attrName", true)"""
+    }.trim()
 
 
 val fritz2Attributes = listOf(

--- a/src/main/kotlin/dev/fritz2/htmlplugin/ide/ConvertTextHTMLCopyPasteProcessor.kt
+++ b/src/main/kotlin/dev/fritz2/htmlplugin/ide/ConvertTextHTMLCopyPasteProcessor.kt
@@ -70,11 +70,16 @@ class ConvertTextHTMLCopyPasteProcessor : CopyPastePostProcessor<TextBlockTransf
         return result
     }
 
-    override fun processTransferableData(project: Project, editor: Editor,
-                                         bounds: RangeMarker,
-                                         caretOffset: Int,
-                                         indented: Ref<Boolean>,
-                                         textValues: MutableList<TextBlockTransferableData>) {
+    override fun processTransferableData(
+        project: Project?,
+        editor: Editor?,
+        bounds: RangeMarker?,
+        caretOffset: Int,
+        indented: Ref<in Boolean>?,
+        textValues: MutableList<out TextBlockTransferableData>?
+    ) {
+        if (project == null || editor == null || textValues == null || bounds == null) return
+
 
         val isDump = DumbService.getInstance(project).isDumb
         logger.debug { "processTransferableData isDump=$isDump" }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,8 +13,8 @@ This plugin simplifies the transformation of HTML code to a fritz2 DSL doing the
     </change-notes>
 
 
-    <depends>com.intellij.modules.java</depends>
     <depends>org.jetbrains.kotlin</depends>
+    <!--<depends>com.intellij.modules.java</depends>-->
 
     <extensions defaultExtensionNs="com.intellij">
         <copyPastePostProcessor
@@ -30,6 +30,5 @@ This plugin simplifies the transformation of HTML code to a fritz2 DSL doing the
             <keyboard-shortcut keymap="$default" first-keystroke="shift meta alt X"/>
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </action>
-        <!--        </group>-->
     </actions>
 </idea-plugin>


### PR DESCRIPTION
### Version changes

This upgrades versions of Gradle to `7.4`, Kotlin to `1.6.10` and the IntelliJ Gradle plugin to `1.5.2`.

### Boolean attributes

Additionally, HTML attributes with Boolean values are now handled differently:
If an HTML attribute has a Boolean value that is `true`, `attr` will be called with the Boolean value over the String representation.

#### Example
If the HTML is `<sometag someattribute="true">...</sometag>`
the plugin will generate `attr("some_attribute", true)`instead of `attr("some_attribute", "true")` in fritz2.

In case of the `aria-hidden` attribute the resulting HTML from the generated fritz2 DSL code would look like this:

![Bildschirmfoto 2022-07-21 um 12 33 16](https://user-images.githubusercontent.com/12587543/180209302-7529e991-b509-4f81-ba30-9e5b80d35c7d.png)
